### PR TITLE
Symfony 3.2 fix

### DIFF
--- a/Twig/DebugTemplate.php
+++ b/Twig/DebugTemplate.php
@@ -1,13 +1,31 @@
 <?php
 namespace Webonaute\TwigDebugHelperBundle\Twig;
 
-abstract class DebugTemplate extends \Twig_Template
+class DebugTemplate extends \Twig_Template
 {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function display(array $context, array $blocks = array())
+	{
+		echo "\n<!-- START: " . $this->getTemplateName() . " -->\n";
+		parent::display($context, $blocks);
+		echo "\n<!-- END: " . $this->getTemplateName() . " -->\n";
+	}
 
-    public function display(array $context, array $blocks = array())
-    {
-        echo "\n<!-- START: " . $this->getTemplateName() . " -->\n";
-        $this->displayWithErrorHandling($this->env->mergeGlobals($context), array_merge($this->blocks, $blocks));
-        echo "\n<!-- END: " . $this->getTemplateName() . " -->\n";
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function doDisplay(array $context, array $blocks = array())
+	{
+		throw new \RuntimeException('This method should not be called. It must be overriden at runtime');
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getTemplateName()
+	{
+		throw new \RuntimeException('This method should not be called. It must be overriden at runtime.');
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "twig",
     "template",
     "symfony",
-    "symfony2",
     "debug",
     "test",
     "helper"
@@ -26,11 +25,10 @@
   },
   "require": {
     "php": ">=5.3.3",
-    "symfony/framework-bundle": "~2.0 || ~3.0",
-    "twig/twig": "~1.12"
+    "symfony/framework-bundle": "^2.0 || ^3.0",
+    "twig/twig": "^1.12"
   },
   "autoload": {
-    "psr-0": {"Webonaute\\TwigDebugHelperBundle": ""}
-  },
-  "target-dir": "Webonaute/TwigDebugHelperBundle"
+    "psr-4": {"Webonaute\\TwigDebugHelperBundle\\": ""}
+  }
 }


### PR DESCRIPTION
Avoid error :
php.CRITICAL: Cannot instantiate abstract class AppBundle\Twig\DebugTemplate {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Cannot instantiate abstract class